### PR TITLE
Split web pack config into base and dev/prod

### DIFF
--- a/build/paths.js
+++ b/build/paths.js
@@ -1,0 +1,9 @@
+const path = require('path');
+
+module.exports = {
+  SRC: path.resolve(__dirname, '..', 'src'),
+
+  DIST: path.resolve(__dirname, '..', 'dist'),
+
+  ASSETS: '/dist'
+};

--- a/build/webpack.config.base.js
+++ b/build/webpack.config.base.js
@@ -1,13 +1,15 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
+const { SRC, DIST } = require('./paths');
 
 module.exports = {
-  mode: 'development',
-  entry: [
-    path.join(__dirname, 'src', 'index.js')
-  ],
+  // mode: 'development',
+  context: path.resolve(__dirname, '..'),
+  entry: {
+    index: path.resolve(SRC, '', 'index.js')
+  },
   output: {
-    path: path.resolve(__dirname, 'dist'),
+    path: DIST,
     filename: 'main.js'
   },
   module: {
@@ -36,7 +38,7 @@ module.exports = {
   },
   plugins: [
     new HtmlWebpackPlugin({
-      template: path.join(__dirname, 'index.html')
+      template: path.join(__dirname, '..', 'index.html')
     })
   ]
 };

--- a/build/webpack.config.dev.js
+++ b/build/webpack.config.dev.js
@@ -1,0 +1,9 @@
+const { merge } = require('webpack-merge');
+
+module.exports = merge(require('./webpack.config.base'), {
+  mode: 'development',
+  watch: true,
+  devtool: 'source-map'
+
+  // All webpack configuration for development environment will go here
+});

--- a/build/webpack.config.dev.js
+++ b/build/webpack.config.dev.js
@@ -2,7 +2,6 @@ const { merge } = require('webpack-merge');
 
 module.exports = merge(require('./webpack.config.base'), {
   mode: 'development',
-  watch: true,
   devtool: 'source-map'
 
   // All webpack configuration for development environment will go here

--- a/build/webpack.config.prod.js
+++ b/build/webpack.config.prod.js
@@ -1,0 +1,7 @@
+const { merge } = require('webpack-merge');
+
+module.exports = merge(require('./webpack.config.base'), {
+  mode: 'production'
+
+  // We'll place webpack configuration for production environment here
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -4233,7 +4233,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
       "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-      "dev": true,
       "requires": {
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
@@ -6469,7 +6468,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -6541,8 +6539,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "jest-worker": {
       "version": "27.3.1",
@@ -6636,8 +6633,7 @@
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "levn": {
       "version": "0.4.1",
@@ -8113,7 +8109,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "dev": true,
       "requires": {
         "kind-of": "^6.0.2"
       }
@@ -8997,7 +8992,6 @@
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
       "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
-      "dev": true,
       "requires": {
         "clone-deep": "^4.0.1",
         "wildcard": "^2.0.0"
@@ -9049,8 +9043,7 @@
     "wildcard": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
-      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
-      "dev": true
+      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "webpack",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "webpack serve"
+    "dev": "webpack serve --config build/webpack.config.dev.js",
+    "prod": "webpack --config build/webpack.config.prod.js"
   },
   "repository": {
     "type": "git",
@@ -61,6 +62,7 @@
     "split-polygon": "^1.0.0",
     "standard": "^16.0.3",
     "styled-components": "^5.3.3",
-    "toposort": "^2.0.2"
+    "toposort": "^2.0.2",
+    "webpack-merge": "^5.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "style-loader": "^3.3.1",
     "webpack": "^5.62.1",
     "webpack-cli": "^4.9.1",
-    "webpack-dev-server": "^4.4.0"
+    "webpack-dev-server": "^4.4.0",
+    "webpack-merge": "^5.8.0"
   },
   "dependencies": {
     "@emotion/react": "^11.7.1",
@@ -62,7 +63,6 @@
     "split-polygon": "^1.0.0",
     "standard": "^16.0.3",
     "styled-components": "^5.3.3",
-    "toposort": "^2.0.2",
-    "webpack-merge": "^5.8.0"
+    "toposort": "^2.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Simulation of a distributed multi-robot collision avoidance algorithm based on the concept of Buffered Voronoi Cells (BVC)*.\\\r An algorithm for deadlock prediction, deadlock recovery, and deadlock recovery success prediction is proposed and implemented.\\\r Deadlock avoidance with right-hand heuristics is also implemented for comparison.",
   "main": "index.js",
   "scripts": {
-    "build": "webpack",
+    "build": "webpack --config build/webpack.config.prod.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "webpack serve --config build/webpack.config.dev.js",
-    "prod": "webpack --config build/webpack.config.prod.js"
+    "prod": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Split web pack config into multiple files, one for dev and one for prod, as well as a common base config file for shared configuration between the two modes.

`npm run dev` and `npm run build` now use those specific configs. Also added `npm run prod` which is an alias for `npm run build`