### PR TITLE
Global sensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 src/server
 dist/
+**/*.DS_Store

--- a/src/swarmjs-core/exampleConfigs/voronoiSorting.ts
+++ b/src/swarmjs-core/exampleConfigs/voronoiSorting.ts
@@ -13,7 +13,7 @@ const simConfig = {
     speed: 15
   },
   robots: {
-    count: 20,
+    count: 10,
     radius: 7,
     controllers: {
       goal: {

--- a/src/swarmjs-core/robot/robot.ts
+++ b/src/swarmjs-core/robot/robot.ts
@@ -4,6 +4,7 @@ import { getDistance } from '../utils/geometry';
 
 import SensorManager from './sensors/sensorManager';
 import ActuatorManager from './actuators/actuatorsManager';
+import Scene from '../scene';
 
 const getController = (robot, controllerDef) => {
   let Func = null;
@@ -44,7 +45,7 @@ export default class Robot {
 
   public waypoint: Vector;
 
-  private sensorManager: any;
+  private sensorManager: SensorManager;
 
   private actuatorManager: any;
 
@@ -68,7 +69,7 @@ export default class Robot {
     public radius: number,
     private envWidth,
     private envHeight,
-    private scene: any
+    private scene: Scene
   ) {
     this.velocity = { x: 0, y: 0 };
     this.velocityScale = 1;
@@ -110,7 +111,6 @@ export default class Robot {
     // Sensor Manager
     this.sensorManager = new SensorManager(this.scene, this, enabledSensors);
     this.sensorManager.start();
-    this.sensorManager.update();
 
     // Goal Planning
     this.updateGoal = getController(this, this.controller.goal);
@@ -124,7 +124,8 @@ export default class Robot {
     // Actuator Manager
     this.actuatorManager = new ActuatorManager(this.scene, this, enabledActuators);
 
-    this.sense = (sensorName, params) => this.sensorManager.sense(sensorName, params);
+
+    this.sense = (sensorName) => this.sensorManager.sense(sensorName);
 
     this.sense.bind(this);
   }
@@ -135,7 +136,7 @@ export default class Robot {
 
   set position(val) {
     Body.set(this.body, 'position', { x: val.x, y: val.y });
-    this.sensorManager.update();
+    this.sensorManager.update(this.scene.timeInstance);
   }
 
   setWaypoint(waypoint) {
@@ -144,7 +145,7 @@ export default class Robot {
 
   timeStep() {
     // Update sensors
-    this.sensorManager.update();
+    this.sensorManager.update(this.scene.timeInstance);
 
     // Update goal
     const newGoalRaw = this.updateGoal(this.goal, this.sensors, this.actuatorManager.actuators);

--- a/src/swarmjs-core/robot/sensors/clustering/closestPuckToGrabberSensor.ts
+++ b/src/swarmjs-core/robot/sensors/clustering/closestPuckToGrabberSensor.ts
@@ -1,5 +1,5 @@
 import { AbstractSensor} from '../sensor';
-import { sensorSamplingTypes, AvailableSensors } from '../sensorManager';
+import { SensorSamplingType, AvailableSensors } from '../sensorManager';
 import { getDistance } from '../../../utils/geometry';
 import Puck from '../../../puck';
 
@@ -11,7 +11,7 @@ class ClosestPuckToGrabber extends AbstractSensor<Puck> {
       AvailableSensors.heading,
       AvailableSensors.pucksNearGrabber
     ];
-    super(robot, scene, name, sensorSamplingTypes.onUpdate, dependencies, initialValue);
+    super(robot, scene, name, SensorSamplingType.onUpdate, dependencies, initialValue);
   }
 
   sample() {

--- a/src/swarmjs-core/robot/sensors/clustering/pucksNearGrabberSensor.ts
+++ b/src/swarmjs-core/robot/sensors/clustering/pucksNearGrabberSensor.ts
@@ -1,5 +1,5 @@
 import { AbstractSensor } from '../sensor';
-import { sensorSamplingTypes, AvailableSensors } from '../sensorManager';
+import { SensorSamplingType, AvailableSensors } from '../sensorManager';
 import { getDistance } from '../../../utils/geometry';
 import Puck from '../../../puck';
 
@@ -13,7 +13,7 @@ class PucksNearGrabberSensor extends AbstractSensor<Puck[]> {
       AvailableSensors.heading,
       AvailableSensors.nearbyPucks
     ];
-    super(robot, scene, name, sensorSamplingTypes.onUpdate, dependencies, []);
+    super(robot, scene, name, SensorSamplingType.onUpdate, dependencies, []);
 
     this.MAX_NEARBY_DISTANCE = robot.radius * 4;
   }

--- a/src/swarmjs-core/robot/sensors/env/envBoundsSensor.ts
+++ b/src/swarmjs-core/robot/sensors/env/envBoundsSensor.ts
@@ -1,11 +1,11 @@
 import { AbstractSensor } from '../sensor';
-import { sensorSamplingTypes } from '../sensorManager';
+import { SensorSamplingType } from '../sensorManager';
 
 const name = 'envBounds';
 
 class EnvironmentBoundsSensor extends AbstractSensor<{x: number, y: number}[]> {
   constructor(robot, scene) {
-    super(robot, scene, name, sensorSamplingTypes.onStart);
+    super(robot, scene, name, SensorSamplingType.onStart);
     this.value = [];
   }
 

--- a/src/swarmjs-core/robot/sensors/env/wallSensor.ts
+++ b/src/swarmjs-core/robot/sensors/env/wallSensor.ts
@@ -1,5 +1,5 @@
 import { AbstractSensor } from '../sensor';
-import { sensorSamplingTypes, AvailableSensors } from '../sensorManager';
+import { SensorSamplingType, AvailableSensors } from '../sensorManager';
 import { distanceBetweenPointAndLine } from '../../../utils/geometry';
 
 const name = 'walls';
@@ -20,7 +20,7 @@ class WallSensor extends AbstractSensor<any[]> {
       AvailableSensors.position,
       AvailableSensors.directions
     ];
-    super(robot, scene, name, sensorSamplingTypes.onUpdate, dependencies, []);
+    super(robot, scene, name, SensorSamplingType.onUpdate, dependencies, []);
 
     this.DETECTION_RADIUS = options.detectionRadius == null ? robot.radius : options.detectionRadius;
   }

--- a/src/swarmjs-core/robot/sensors/nearby/nearbyObstaclesSensor.ts
+++ b/src/swarmjs-core/robot/sensors/nearby/nearbyObstaclesSensor.ts
@@ -1,5 +1,5 @@
 import { AbstractSensor } from '../sensor';
-import { sensorSamplingTypes, AvailableSensors } from '../sensorManager';
+import { SensorSamplingType, AvailableSensors } from '../sensorManager';
 import generateStaticObject from '../../../staticObjects/staticObjectFactory';
 
 const name = 'nearbyObstacles';
@@ -23,7 +23,7 @@ class NearbyObstaclesSensor extends AbstractSensor<any[]> {
       AvailableSensors.position,
       AvailableSensors.nearbyPucks
     ];
-    super(robot, scene, name, sensorSamplingTypes.onUpdate, dependencies, []);
+    super(robot, scene, name, SensorSamplingType.onUpdate, dependencies, []);
     
     this.DETECTION_RADIUS = options.detectionRadius == null ? robot.radius * 10 : options.detectionRadius;
   }

--- a/src/swarmjs-core/robot/sensors/nearby/nearbyPucksSensor.ts
+++ b/src/swarmjs-core/robot/sensors/nearby/nearbyPucksSensor.ts
@@ -1,6 +1,6 @@
 import { AbstractSensor } from '../sensor';
 import Puck from '../../../puck';
-import { sensorSamplingTypes, AvailableSensors } from '../sensorManager';
+import { SensorSamplingType, AvailableSensors } from '../sensorManager';
 
 const name = 'nearbyPucks';
 
@@ -8,7 +8,7 @@ class NearbyPucksSensor extends AbstractSensor<Puck[]> {
   private MAX_NEARBY_DISTANCE: number;
   constructor(robot, scene) {
     const dependencies = [AvailableSensors.position];
-    super(robot, scene, name, sensorSamplingTypes.onUpdate, dependencies, []);
+    super(robot, scene, name, SensorSamplingType.onUpdate, dependencies, []);
 
 
     this.MAX_NEARBY_DISTANCE = robot.radius * 20;

--- a/src/swarmjs-core/robot/sensors/nearby/neighborsSensor.ts
+++ b/src/swarmjs-core/robot/sensors/nearby/neighborsSensor.ts
@@ -1,6 +1,6 @@
 import Scene from '../../../scene';
 import { AbstractSensor } from '../sensor';
-import { sensorSamplingTypes, AvailableSensors } from '../sensorManager';
+import { SensorSamplingType, AvailableSensors } from '../sensorManager';
 import Robot from '../../robot';
 
 const name = 'neighbors';
@@ -23,7 +23,7 @@ const getNeighbors = (scene: Scene, robotId): Robot[] => {
 
 class NeighborsSensor extends AbstractSensor<Robot[]> {
   constructor(robot, scene) {
-    super(robot, scene, name, sensorSamplingTypes.onUpdate,[AvailableSensors.position] , []);
+    super(robot, scene, name, SensorSamplingType.onUpdate,[AvailableSensors.position] , []);
   }
 
   sample() {

--- a/src/swarmjs-core/robot/sensors/pose/directionsSensor.ts
+++ b/src/swarmjs-core/robot/sensors/pose/directionsSensor.ts
@@ -2,7 +2,7 @@
 // Usefull for controllers to easily set a heading direction depending on sensor readings.
 
 import { AbstractSensor } from '../sensor';
-import { sensorSamplingTypes, AvailableSensors } from '../sensorManager';
+import { SensorSamplingType, AvailableSensors } from '../sensorManager';
 import { getAbsolutePointFromLengthAndAngle } from '../../../utils/geometry';
 
 const name = 'directions';
@@ -43,7 +43,7 @@ class DirectionsSensor extends AbstractSensor<directionType | Record<string, unk
       AvailableSensors.position,
       AvailableSensors.orientation
     ];
-    super(robot, scene, name, sensorSamplingTypes.onUpdate, dependencies, defaultValue());
+    super(robot, scene, name, SensorSamplingType.onUpdate, dependencies, defaultValue());
   }
 
   sample() {

--- a/src/swarmjs-core/robot/sensors/pose/headingSensor.ts
+++ b/src/swarmjs-core/robot/sensors/pose/headingSensor.ts
@@ -1,5 +1,5 @@
 import { AbstractSensor } from '../sensor';
-import { sensorSamplingTypes, AvailableSensors } from '../sensorManager';
+import { SensorSamplingType, AvailableSensors } from '../sensorManager';
 import { getAbsolutePointFromLengthAndAngle } from '../../../utils/geometry';
 import { Vector } from 'matter-js';
 
@@ -11,7 +11,7 @@ class HeadingSensor extends AbstractSensor<Vector> {
       AvailableSensors.position,
       AvailableSensors.orientation
     ];
-    super(robot, scene, name, sensorSamplingTypes.onUpdate, dependencies, {x: null, y: null});
+    super(robot, scene, name, SensorSamplingType.onUpdate, dependencies, {x: null, y: null});
   }
 
   sample() {

--- a/src/swarmjs-core/robot/sensors/pose/orientationSensor.ts
+++ b/src/swarmjs-core/robot/sensors/pose/orientationSensor.ts
@@ -1,12 +1,12 @@
 import { AbstractSensor } from '../sensor';
-import { sensorSamplingTypes } from '../sensorManager';
+import { SensorSamplingType } from '../sensorManager';
 import { normalizeAngle } from '../../../utils/geometry';
 
 const name = 'orientation';
 
 class OrientationSensor extends AbstractSensor<number> {
   constructor(robot, scene) {
-    super(robot, scene, name, sensorSamplingTypes.onUpdate)
+    super(robot, scene, name, SensorSamplingType.onUpdate)
   }
 
   sample() {

--- a/src/swarmjs-core/robot/sensors/pose/positionSensor.ts
+++ b/src/swarmjs-core/robot/sensors/pose/positionSensor.ts
@@ -17,7 +17,7 @@
 
 import { Vector } from 'matter-js';
 import { AbstractSensor } from '../sensor';
-import { sensorSamplingTypes, AvailableSensors } from '../sensorManager';
+import { SensorSamplingType, AvailableSensors } from '../sensorManager';
 
 const name = 'position';
 
@@ -25,7 +25,7 @@ const name = 'position';
 class PositionSensor extends AbstractSensor<Vector> {
   constructor(robot, scene) {
     const dependencies = [];
-    super(robot, scene, name, sensorSamplingTypes.onUpdate, dependencies, {x: null, y: null});
+    super(robot, scene, name, SensorSamplingType.onUpdate, dependencies, {x: null, y: null});
   }
 
   sample() {

--- a/src/swarmjs-core/robot/sensors/pose/prevPositionSensor.ts
+++ b/src/swarmjs-core/robot/sensors/pose/prevPositionSensor.ts
@@ -1,12 +1,12 @@
 import { Vector } from 'matter-js';
 import { AbstractSensor } from '../sensor';
-import { AvailableSensors, sensorSamplingTypes } from '../sensorManager';
+import { AvailableSensors, SensorSamplingType } from '../sensorManager';
 
 const name = 'prevPosition';
 
 class PrevPositionSensor extends AbstractSensor<Vector> {
   constructor(robot, scene) {
-    super(robot, scene, name, sensorSamplingTypes.onUpdate, [AvailableSensors.position], {x: null, y: null});
+    super(robot, scene, name, SensorSamplingType.onUpdate, [AvailableSensors.position], {x: null, y: null});
   }
 
   sample() {

--- a/src/swarmjs-core/robot/sensors/sensor.ts
+++ b/src/swarmjs-core/robot/sensors/sensor.ts
@@ -1,25 +1,30 @@
 import Scene from "../../scene";
 import Robot from "../robot";
+import { SensorSamplingType } from "./sensorManager";
 
 
 export interface Sensor<T> {
-  sample(): void;
+  sample(tick?: number, force?: boolean): void
   read(): T;
+  type: SensorSamplingType;
+  name: string
+  dependencies: Sensor<unknown>[]
 }
 
 export abstract class AbstractSensor<T> implements Sensor<T> {
   protected robot: Robot;
   protected scene: Scene;
-  name: string;
-  private type: any;
-  private dependencies: Sensor<any>[];
+  private _name: string;
+
+  private _type: SensorSamplingType;
+  public dependencies: Sensor<unknown>[];
   protected value: T;  
   
-  protected constructor(robot, scene, name, samplingType, dependencies = [], initialValue: T = undefined) {
+  protected constructor(robot: Robot, scene: Scene, name: string, samplingType: SensorSamplingType, dependencies = [], initialValue: T = undefined) {
     this.robot = robot;
     this.scene = scene;
-    this.name = name;
-    this.type = samplingType;
+    this._name = name;
+    this._type = samplingType;
     this.dependencies = dependencies;
     this.value = initialValue;
 
@@ -30,11 +35,59 @@ export abstract class AbstractSensor<T> implements Sensor<T> {
     // });
   }
 
-  sample(): void {
-    // Must be overridden
+  public get type(): SensorSamplingType {
+    return this._type;
   }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  abstract sample(tick?: number): void
 
   read() {
     return this.value;
   }
+}
+
+export abstract class GlobalSensor<T, S> implements Sensor<Map<T,S>> {
+
+  protected scene: Scene;
+  private _name: string;
+  private _type: SensorSamplingType;
+  public dependencies: Sensor<unknown>[];
+  protected value: Map<T,S>;
+  private _lastSampledTick: number;
+
+  protected constructor(scene, name, samplingType: SensorSamplingType, dependencies = [], initialValue: Map<T,S> = undefined) {
+    this.scene = scene;
+    this._name = name;
+    this._type = samplingType;
+    this.dependencies = dependencies;
+    this.value = initialValue;
+  }
+  
+  public get name(): string {
+    return this._name;
+  }
+
+  public get type(): SensorSamplingType {
+    return this._type;
+  }
+
+  sample(tick?: number, force = false): void {
+    if(!force) {
+      if(tick === this._lastSampledTick) return;
+  
+      if(tick <= this._lastSampledTick) throw new Error(`Trying to sample sensor ${this.name} with tick ${tick} but last sampled tick is ${this._lastSampledTick}`);
+    }
+
+    this.value = this.getValues()
+  }
+
+  read() { 
+    return this.value
+  }
+
+  abstract getValues(): Map<T,S>
 }

--- a/src/swarmjs-core/robot/sensors/state/puckGoalAreaSensor.ts
+++ b/src/swarmjs-core/robot/sensors/state/puckGoalAreaSensor.ts
@@ -1,12 +1,12 @@
 import { AbstractSensor } from '../sensor';
-import { AvailableSensors, sensorSamplingTypes } from '../sensorManager';
+import { AvailableSensors, SensorSamplingType } from '../sensorManager';
 
 const name = 'puckGoalAreaSensor';
 
 class PuckGoalAreaSensor extends AbstractSensor<boolean> {
   constructor(robot, scene) {
     const dependencies = [AvailableSensors.position];
-    super(robot, scene, name, sensorSamplingTypes.onUpdate, dependencies, false);
+    super(robot, scene, name, SensorSamplingType.onUpdate, dependencies, false);
   }
 
   sample() {

--- a/src/swarmjs-core/robot/sensors/state/reachedGoalSensor.ts
+++ b/src/swarmjs-core/robot/sensors/state/reachedGoalSensor.ts
@@ -1,12 +1,12 @@
 import { AbstractSensor } from '../sensor';
-import { AvailableSensors, sensorSamplingTypes } from '../sensorManager';
+import { AvailableSensors, SensorSamplingType } from '../sensorManager';
 
 const name = 'reachedGoal';
 
 class ReachedGoalSensor extends AbstractSensor<boolean> {
   constructor(robot, scene) {
     const dependencies = [AvailableSensors.position];
-    super(robot, scene, name, sensorSamplingTypes.onUpdate, dependencies, false);
+    super(robot, scene, name, SensorSamplingType.onUpdate, dependencies, false);
   }
 
   sample() {

--- a/src/swarmjs-core/robot/sensors/state/reachedWaypointSensor.ts
+++ b/src/swarmjs-core/robot/sensors/state/reachedWaypointSensor.ts
@@ -1,12 +1,12 @@
 import { AbstractSensor } from '../sensor';
-import { AvailableSensors, sensorSamplingTypes } from '../sensorManager';
+import { AvailableSensors, SensorSamplingType } from '../sensorManager';
 
 const name = 'reachedWaypoint';
 
 class ReachedWaypointSensor extends AbstractSensor<boolean> {
   constructor(robot, scene) {
     const dependencies = [AvailableSensors.position]
-    super(robot, scene, name, sensorSamplingTypes.onUpdate, dependencies, false);
+    super(robot, scene, name, SensorSamplingType.onUpdate, dependencies, false);
   }
 
   sample() {

--- a/src/swarmjs-core/robot/sensors/voronoi/GlobalVoronoiSensor.ts
+++ b/src/swarmjs-core/robot/sensors/voronoi/GlobalVoronoiSensor.ts
@@ -1,0 +1,56 @@
+import { Global } from "@emotion/react";
+import { Delaunay, Voronoi } from "d3-delaunay";
+import Scene from "../../../scene";
+import Robot from "../../robot";
+import { AbstractSensor, GlobalSensor, Sensor } from "../sensor";
+import { SensorSamplingType } from "../sensorManager";
+
+
+export class GlobalVoronoiSensor extends GlobalSensor<Robot, Voronoi<Robot>> {
+
+  private static instance: GlobalVoronoiSensor;
+  static readonly SENSOR_NAME = "globalVoronoiJohnTest";
+
+  private voronoi: Voronoi<Robot>
+
+  private constructor(scene) {
+    super(scene, GlobalVoronoiSensor.SENSOR_NAME, SensorSamplingType.onUpdate);
+  }
+
+  // Get instance of singleton
+  static getInstance(scene?) {
+    if(!this.instance) {
+      if (!scene) throw new Error("Scene is required to create GlobalVoronoiSensor");
+      this.instance = new this(scene);
+    }
+    return this.instance;
+  }
+
+  getValues(): Map<Robot, Voronoi<Robot>> {
+
+    if(!this.scene?.robots || this.scene.robots.length === 0) return new Map();
+
+    //TODO: Update the existing voronoi rather than create a new one
+    this.voronoi = Delaunay.from(this.scene.robots,
+      (robot) => robot.body.position.x,
+      (robot) => robot.body.position.y)
+      .voronoi([0,0,this.scene.width,this.scene.height]);
+
+    if(!this.voronoi) {
+      this.voronoi = Delaunay.from(this.scene.robots,
+        (robot) => robot.body.position.x,
+        (robot) => robot.body.position.y)
+        .voronoi([0,0,this.scene.width,this.scene.height]);
+    } else {
+      this.voronoi.update()
+    }
+
+    const ret = new Map<Robot, Voronoi<Robot>>();
+  
+    this.scene.robots.forEach(robot => {
+      ret.set(robot, this.voronoi)
+    });
+
+    return ret
+  }
+}

--- a/src/swarmjs-core/robot/sensors/voronoi/VoronoiSensor.ts
+++ b/src/swarmjs-core/robot/sensors/voronoi/VoronoiSensor.ts
@@ -1,0 +1,41 @@
+import { Delaunay, Voronoi } from "d3-delaunay";
+import Scene from "../../../scene";
+import Robot from "../../robot";
+import { AbstractSensor } from "../sensor";
+import { SensorSamplingType } from "../sensorManager";
+import { GlobalVoronoiSensor } from "./GlobalVoronoiSensor";
+
+
+// const name = "voronoiJohnTest";
+export class VoronoiCellSensor extends AbstractSensor<Delaunay.Polygon> {
+
+  static sensorName = "voronoiJohnTest";
+
+  private globalSensor: GlobalVoronoiSensor;
+
+
+  constructor(robot: Robot, scene: Scene) {
+    super(robot, scene, VoronoiCellSensor.sensorName, SensorSamplingType.onUpdate, [], undefined as Delaunay.Polygon);
+
+    this.globalSensor = GlobalVoronoiSensor.getInstance(scene);
+  }
+
+
+  sample(tick?: number): void {
+
+    //Sample the global sensor
+    if(!tick && tick !== 0) throw new Error("Simulation Tick required to sample voronoi sensor");
+
+    this.globalSensor.sample(tick)
+
+    //Read the global sensor and filter this sensor's value
+    const voronoi = this.globalSensor.read().get(this.robot)
+
+    this.value = voronoi?.cellPolygon(this.robot.id)
+  }
+}
+
+export default {
+  name: VoronoiCellSensor.sensorName,
+  Sensor: VoronoiCellSensor
+};

--- a/src/swarmjs-core/robot/sensors/voronoi/bufferedVoronoiCellSensor.ts
+++ b/src/swarmjs-core/robot/sensors/voronoi/bufferedVoronoiCellSensor.ts
@@ -1,7 +1,10 @@
+import { Delaunay } from 'd3-delaunay';
 import * as Offset from 'polygon-offset';
+import Scene from '../../../scene';
+import Robot from '../../robot';
 
 import { AbstractSensor } from '../sensor';
-import { sensorSamplingTypes, AvailableSensors } from '../sensorManager';
+import { SensorSamplingType, AvailableSensors } from '../sensorManager';
 
 const name = 'BVC';
 
@@ -21,14 +24,14 @@ const calculateBVCfromVC = (cell, position, radius) => {
   return padding;
 };
 
-class BufferedVoronoiCellSensor extends AbstractSensor<number[][]> {
-  constructor(robot, scene) {
+class BufferedVoronoiCellSensor extends AbstractSensor<Delaunay.Polygon> {
+  constructor(robot: Robot, scene: Scene) {
 
     const dependencies = [
       AvailableSensors.position,
       AvailableSensors.obstaclesAwareVoronoiCell
     ];
-    super(robot, scene, name, sensorSamplingTypes.onUpdate, dependencies);
+    super(robot, scene, name, SensorSamplingType.onUpdate, dependencies);
   }
 
   sample() {

--- a/src/swarmjs-core/robot/sensors/voronoi/closestObstaclePointSensor.ts
+++ b/src/swarmjs-core/robot/sensors/voronoi/closestObstaclePointSensor.ts
@@ -1,5 +1,5 @@
 import { AbstractSensor } from '../sensor';
-import { sensorSamplingTypes, AvailableSensors } from '../sensorManager';
+import { SensorSamplingType, AvailableSensors } from '../sensorManager';
 import { Vector } from 'matter-js';
 
 const name = 'closestObstaclePoint';
@@ -10,7 +10,7 @@ class ClosestObstaclePointSensor extends AbstractSensor<Vector> {
       AvailableSensors.position,
       AvailableSensors.nearbyObstacles
     ];
-    super(robot, scene, name, sensorSamplingTypes.onUpdate, dependencies, undefined);
+    super(robot, scene, name, SensorSamplingType.onUpdate, dependencies, undefined);
   }
 
   sample() {


### PR DESCRIPTION
This introduces the idea of global sensors to SwarmJS, as well the global voronoi sensor.

Global sensors are useful for sensors which are computationally expensive and can benefit from sharing computation across agents. Global sensors return a map of Robots to sensor readings. That way it is possible to have a single global sensor return the same data to all agents or alter the data returned to each agent.

Agents themselves shouldn't directly use the global sensors but should instead use a sensor. which depends on that global sensor and wraps it for use by a single agent.