### PR TITLE
Remove pucks from scene upon reaching their goal

### DIFF
--- a/src/swarmjs-core/puck.ts
+++ b/src/swarmjs-core/puck.ts
@@ -95,7 +95,11 @@ export default class Puck {
   }
 
   reachedGoal() {
-    return this.reachedDist(this.groupGoal, this.goalReachedDist);
+    const reached = this.reachedDist(this.groupGoal, this.goalReachedDist);
+    if (reached) {
+      this.scene.removePuck(this)
+    }
+    return reached
   }
 
   deepInGoal() {

--- a/src/swarmjs-core/scene.ts
+++ b/src/swarmjs-core/scene.ts
@@ -37,6 +37,8 @@ export default class Scene {
   unpause: () => void;
   setSpeed: (scale: any) => void;
   voronoiSensor: GlobalVoronoiSensor;
+
+  
   constructor(
     envConfig,
     robotsConfig,
@@ -194,6 +196,17 @@ export default class Scene {
     this.timeInstance = this.engine.timing.timestamp;
 
     Engine.clear(this.engine);
+  }
+
+  removePuck(puck: Puck) {
+
+    this.pucks = this.pucks.filter( (ele) => {
+      return ele != puck
+    }) //remove from tracking outside the physics simulation
+
+    this.numOfPucks = this.numOfPucks - 1
+
+    World.remove(this.world, puck.body) //Remove from physics simulation world
   }
 
   // TODO: Enable rendering of voronoi diagram in all cases


### PR DESCRIPTION
Pucks are removed from the physics simulation as well as the layer above which is responsible for the voronoi diagrams. They are still registered with d3 for rendering however, so they continue to render at their last know location without any affect on the sim